### PR TITLE
Fix module cache clearing in builder.js

### DIFF
--- a/src/builder.js
+++ b/src/builder.js
@@ -72,8 +72,10 @@ function buildWidget() {
 
   try {
     console.log('📝 Processing CSS component...');
-    delete require.cache[path.join(componentsDir, 'css.js')];
-    require(path.join(componentsDir, 'css.js'));
+    const cssModule = path.join(componentsDir, 'css.js');
+    const cssKey = require.resolve(cssModule);
+    delete require.cache[cssKey];
+    require(cssModule);
   } catch (error) {
     generateErrorPage('CSS', error, distDir);
     buildSuccess = false;
@@ -82,8 +84,10 @@ function buildWidget() {
   if (buildSuccess) {
     try {
       console.log('⚡ Processing JavaScript component...');
-      delete require.cache[path.join(componentsDir, 'javascript.js')];
-      require(path.join(componentsDir, 'javascript.js'));
+      const jsModule = path.join(componentsDir, 'javascript.js');
+      const jsKey = require.resolve(jsModule);
+      delete require.cache[jsKey];
+      require(jsModule);
     } catch (error) {
       generateErrorPage('JavaScript', error, distDir);
       buildSuccess = false;
@@ -93,8 +97,10 @@ function buildWidget() {
   if (buildSuccess) {
     try {
       console.log('🔧 Processing iframe-resizer-javascript component...');
-      delete require.cache[path.join(componentsDir, 'iframe-resizer-javascript.js')];
-      require(path.join(componentsDir, 'iframe-resizer-javascript.js'));
+      const iframeModule = path.join(componentsDir, 'iframe-resizer-javascript.js');
+      const iframeKey = require.resolve(iframeModule);
+      delete require.cache[iframeKey];
+      require(iframeModule);
     } catch (error) {
       generateErrorPage('iframe-resizer-javascript', error, distDir);
       buildSuccess = false;
@@ -104,8 +110,10 @@ function buildWidget() {
   if (buildSuccess) {
     try {
       console.log('🏗️  Processing HTML component...');
-      delete require.cache[path.join(componentsDir, 'html.js')];
-      require(path.join(componentsDir, 'html.js'));
+      const htmlModule = path.join(componentsDir, 'html.js');
+      const htmlKey = require.resolve(htmlModule);
+      delete require.cache[htmlKey];
+      require(htmlModule);
     } catch (error) {
       generateErrorPage('HTML', error, distDir);
       buildSuccess = false;


### PR DESCRIPTION
This PR fixes the module cache clearing logic in builder.js by replacing `path.join()` with `require.resolve()` for proper cache key resolution.

## Problem
The original code used `path.join()` to construct cache keys for `delete require.cache[...]`, but Node.js stores modules in `require.cache` using absolute paths that match the format returned by `require.resolve()`. This mismatch meant that cache entries were never actually cleared, causing stale module data during rebuilds.

## Solution
Replace `path.join()` with `require.resolve()` to get the correct cache keys for all four component loading sections:
- CSS component
- JavaScript component
- iframe-resizer-javascript component
- HTML component

## Technical Details
Before (incorrect):
```javascript
delete require.cache[path.join(componentsDir, "css.js")];
```

After (correct):
```javascript
const cssModule = path.join(componentsDir, "css.js");
const cssKey = require.resolve(cssModule);
delete require.cache[cssKey];
```

## Testing
✅ Development server now correctly rebuilds widgets when component files are modified
✅ All four components (CSS, JavaScript, iframe-resizer, HTML) process without errors
✅ Widget builds successfully with proper cache invalidation

This fix is based on the proven solution from PR #11 in spilnoschool-document-viewer repository.

---
**Link to Devin run:** https://app.devin.ai/sessions/1e6764b365b64928a13ee1920a3b1ea8
**Requested by:** yevhen.porechnyi@corezoid.com